### PR TITLE
[FIX] #8 メッセージをプロパティファイルから取得するように変更しました。

### DIFF
--- a/src/main/java/com/portal/z/common/domain/util/Utility.java
+++ b/src/main/java/com/portal/z/common/domain/util/Utility.java
@@ -5,11 +5,19 @@ import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Locale;
 
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
+import org.springframework.context.NoSuchMessageException;
 import org.springframework.stereotype.Component;
 
 @Component("Utility")
 public class Utility {
+
+    @Autowired
+    private MessageSource messageSource;
 
     /**
      * サーバーに保存されているファイルを取得して、byte配列に変換する.
@@ -26,5 +34,26 @@ public class Utility {
         byte[] bytes = Files.readAllBytes(p);
 
         return bytes;
+    }
+
+    /**
+     * メッセージ取得共通処理<br>
+     * 
+     * messageKeyに該当するメッセージプロパティのメッセージを取得します。
+     * messageKeyに該当するメッセージが存在しない場合、MessageKeyNotExistsのメッセージを返します。
+     * 
+     * @param messageKey メッセージプロパティのKEY
+     * @return メッセージ(メッセージプロパティのVALUE)
+     */
+    public String getMsg(String messageKey) {
+        String message = "";
+
+        try {
+            message = messageSource.getMessage(messageKey, null, Locale.getDefault());
+        } catch (NoSuchMessageException ne) {
+            message = messageSource.getMessage("MessageKeyNotExists", null, Locale.getDefault());
+        }
+
+        return message;
     }
 }

--- a/src/main/java/com/portal/z/user/controller/userController.java
+++ b/src/main/java/com/portal/z/user/controller/userController.java
@@ -13,7 +13,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Controller;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
@@ -24,6 +23,14 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import com.portal.z.common.domain.model.AppUserDetails;
+import com.portal.z.common.domain.model.Role;
+import com.portal.z.common.domain.model.User;
+import com.portal.z.common.domain.model.Userrole;
+import com.portal.z.common.domain.service.RoleService;
+import com.portal.z.common.domain.service.UserService;
+import com.portal.z.common.domain.service.UserroleService;
+import com.portal.z.common.domain.util.Utility;
 import com.portal.z.user.domain.model.CreateOrder;
 import com.portal.z.user.domain.model.InputForm;
 import com.portal.z.user.domain.model.UpdateOrder;
@@ -31,16 +38,6 @@ import com.portal.z.user.domain.model.UserListXlsxView;
 
 import lombok.extern.slf4j.Slf4j;
 
-import com.portal.z.common.domain.model.User;
-import com.portal.z.common.domain.model.Userrole;
-import com.portal.z.common.domain.model.Role;
-import com.portal.z.common.domain.service.UserService;
-import com.portal.z.common.domain.service.UserroleService;
-import com.portal.z.common.domain.util.Utility;
-import com.portal.z.common.domain.service.RoleService;
-import com.portal.z.common.domain.model.AppUserDetails;
-
-@Transactional
 @Controller
 @Slf4j
 public class userController {
@@ -248,7 +245,7 @@ public class userController {
         } catch (DuplicateKeyException de) {
             // 一意制約エラーの処理(後付けでユーザーIDのフィールドにエラーを設定する。)
             FieldError fieldError = new FieldError(bindingResult.getObjectName(), "user_id", form.getUser_id(), false,
-                    null, null, "存在するユーザーIDなので登録できません。");
+                    null, null, utility.getMsg("DuplicatedUserId"));
             bindingResult.addError(fieldError);
             // GETリクエスト用のメソッドを呼び出して、ユーザー登録画面に戻る
             return getSignUp(form, model);

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -59,3 +59,9 @@ AbstractUserDetailsAuthenticationProvider.expired=アカウントの有効期限
 AbstractUserDetailsAuthenticationProvider.credentialsExpired=パスワードの有効期限が切れています。
 AbstractUserDetailsAuthenticationProvider.badCredentials=ログインIDまはたパスワードが間違っています。
 AbstractUserDetailsAuthenticationProvider.UsernameNotFound=ログインIDが間違っています。
+
+# =======================================
+# 未整理のメッセージ(仮)
+# =======================================
+DuplicatedUserId=存在するユーザIDなので登録できません。
+MessageKeyNotExists=【(要対応)メッセージが存在しません！】

--- a/環境構築補足.md
+++ b/環境構築補足.md
@@ -7,7 +7,7 @@
 環境構築手順
 -------
 １．GitHubアカウントを作成し、自PCにgitツールをインストールします。  
-　　⇒アカウント参考（https://shimapuku.com/development/github-account )  
+　　⇒アカウント参考（https://note.com/snmal_jp/n/n3ef510a8181e )  
 　　⇒ツール参考（https://qiita.com/SkyLaptor/items/6347f38c8c010f4d5bd2  )  
 　　※作業手順は公開鍵の登録まででOKです。  
 ２．JDKをインストールします。  


### PR DESCRIPTION
以下の件の対応です。
https://github.com/StudyGroup202010/portal/pull/89/files/830ffe6b5340c1128667568c00a83378d08176ba#r517683118

プロパティファイルからメッセージを取得する処理をUtilityクラスに追加しました。
該当するメッセージがないときは専用のメッセージを出して、メッセージの設定誤りをわかりやすくしました。
メッセージプロパティは、今後整理する時があると思うので、暫定で下の方に新規追加しました。

【参考：経緯】
>> もしそうであれば、もう一歩踏み込んで、エラーメッセージをmessages.propertiesから拾うようにしたいですね。
>> この部分は、他でも使う処理になるので、なるべく共通化しておきたいからです。 😎
>
> エラーメッセージをmessages.propertiesから取得するようにした、エラーメッセージ用の共通処理をつくる、という理解でいいでしょうか？
> いったんコード書いてみます。
> それで認識があってるか確認させてください🙇‍♂️

