### PR TITLE
 #4 CSV出力の際、列名もヘッダとして出力されるように対応しました。

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,11 @@
                   </exclusion>
                 </exclusions>
         </dependency>
+        <!-- csv出力 -->
+		<dependency>
+	        <groupId>com.fasterxml.jackson.dataformat</groupId>
+	        <artifactId>jackson-dataformat-csv</artifactId>
+	    </dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/portal/z/common/domain/logic/UserRowCallbackHandler.java
+++ b/src/main/java/com/portal/z/common/domain/logic/UserRowCallbackHandler.java
@@ -20,17 +20,23 @@ public class UserRowCallbackHandler implements RowCallbackHandler {
             File file = new File("userlist.csv");
             FileWriter fw = new FileWriter(file.getAbsoluteFile());
             BufferedWriter bw = new BufferedWriter(fw);
+            
+            //カラム名をヘッダとして出力するために、一旦Stringに書き込み＆改行し、flush()で強制的に書き込み
+            String col = "user_id,user_due_date,pass_update,login_miss_times,lock_flg,enabled_flg";
+            bw.write(col);
+            bw.newLine();
+            bw.flush();
 
             //取得件数分loop
             do {
 
                 //ResultSetから値を取得してStringにセット
                 String str = rs.getString("user_id")       + ","
-                        + rs.getDate("user_due_date")   + ","
-                        + rs.getDate("pass_update")     + ","
-                        + rs.getInt("login_miss_times") + ","
-                        + rs.getBoolean("lock_flg")     + ","
-                        + rs.getBoolean("enabled_flg");
+                           + rs.getDate("user_due_date")   + ","
+                           + rs.getDate("pass_update")     + ","
+                           + rs.getInt("login_miss_times") + ","
+                           + rs.getBoolean("lock_flg")     + ","
+                           + rs.getBoolean("enabled_flg");
 
                 //ファイルに書き込み＆改行
                 bw.write(str);

--- a/src/main/java/com/portal/z/common/domain/logic/UserRowCallbackHandler.java
+++ b/src/main/java/com/portal/z/common/domain/logic/UserRowCallbackHandler.java
@@ -21,7 +21,7 @@ public class UserRowCallbackHandler implements RowCallbackHandler {
             FileWriter fw = new FileWriter(file.getAbsoluteFile());
             BufferedWriter bw = new BufferedWriter(fw);
             
-            //カラム名をヘッダとして出力するために、一旦Stringに書き込み＆改行し、flush()で強制的に書き込み
+            //カラム名をヘッダとして出力するために、一旦Stringにセットし仮書き込み＆改行、flush()で強制的に書き込み
             String col = "user_id,user_due_date,pass_update,login_miss_times,lock_flg,enabled_flg";
             bw.write(col);
             bw.newLine();
@@ -38,7 +38,7 @@ public class UserRowCallbackHandler implements RowCallbackHandler {
                            + rs.getBoolean("lock_flg")     + ","
                            + rs.getBoolean("enabled_flg");
 
-                //ファイルに書き込み＆改行
+                //ファイルに仮書き込み＆改行
                 bw.write(str);
                 bw.newLine();
 

--- a/src/main/java/com/portal/z/common/domain/repository/UserDaoJdbcImpl.java
+++ b/src/main/java/com/portal/z/common/domain/repository/UserDaoJdbcImpl.java
@@ -31,7 +31,7 @@ public class UserDaoJdbcImpl implements UserDao {
                 + "   user_id"
                 ;
 
-        // ResultSetExtractorの生成
+        // ResultSetExtractorの生成　→使ってないと思う。このコメント削除？
         //　時間がかかるような処理を実行して、処理が終わったら結果を受け取るという方式
         UserRowCallbackHandler handler = new UserRowCallbackHandler();
 

--- a/src/main/java/com/portal/z/common/domain/repository/UserMapper.java
+++ b/src/main/java/com/portal/z/common/domain/repository/UserMapper.java
@@ -20,6 +20,9 @@ public interface UserMapper {
 
     // 全件検索用メソッド
     public List<User> selectMany();
+    
+    // 全件検索用メソッド
+    public List<User> selectCsv();
 
     // １件更新用メソッド
     public boolean updateOne(User user);

--- a/src/main/java/com/portal/z/common/domain/service/UserService.java
+++ b/src/main/java/com/portal/z/common/domain/service/UserService.java
@@ -52,6 +52,14 @@ public class UserService {
         // selectOne実行
         return userMapper.selectOne(user_id);
     }
+    
+    /**
+     * ｃｓｖ取得用メソッド.
+     */
+    public List<User> selectCsv() {
+        // csv用に取得
+        return userMapper.selectCsv();
+    }
 
     /**
      * １件更新用メソッド.

--- a/src/main/resources/com/portal/z/common/domain/repository/UserMapper.xml
+++ b/src/main/resources/com/portal/z/common/domain/repository/UserMapper.xml
@@ -91,6 +91,21 @@
         order by
           user_id
     </select>
+    
+    <!-- csv用検索 -->
+    <select id="selectCsv" resultMap="user">
+        select
+           user_id
+          ,user_due_date
+          ,pass_update
+          ,login_miss_times
+          ,lock_flg
+          ,enabled_flg
+        from
+          zm001_user
+        order by
+          user_id
+    </select>
 
     <!-- １件更新 -->
     <update id="updateOne" parameterType="com.portal.z.common.domain.model.User">


### PR DESCRIPTION
#4 の対応です。
カラム名をCSVの一番初めの行に出力させヘッダとして見えるようにしました。

方法は
　１．一旦Stringにカラム名を直接セット
　２．write()で書き込み
　３．newLine()で改行
　４．flush()で強制的に書き込み
という流れです。

SQLで列名取得することもできましたが、列名のみで列名と行を組み合わせて取得する方法を探すことができませんでした。
参考：PostgreSQLでテーブル名カラム名を取得する方法（列名のみのため断念）
http://chopl.in/post/2013/11/07/how_to_retrieve_tables_and_columns_with_postgres/

UserRowCallbackHandler.javaで列名を直接書き、Stringにセットする方法で
とりあえず形になりましたので、こちらの方法で一旦プルリクエストします。
また改善の余地あればご教示の程よろしくお願いいたします。

※flush()と混同しないようにwrite()のコメントを”仮書き込み”としました。
こちらも問題あればご指摘お願いいたします。
