### PR TITLE
[fix] #166対応　問い合わせフォームのメールアドレス初期値変更

### DIFF
--- a/src/main/java/com/portal/z/contact/controller/ContactController.java
+++ b/src/main/java/com/portal/z/contact/controller/ContactController.java
@@ -48,7 +48,6 @@ public class ContactController {
         AppUserDetails user_auth = (AppUserDetails) SecurityContextHolder.getContext().getAuthentication()
                 .getPrincipal();
         form.setContact_name(user_auth.getUsername());  // ユーザID
-        form.setContact_email(user_auth.getUsername()); // メールアドレス
         model.addAttribute("contactForm", form);
 
         // コンテンツ部分に問い合わせ画面を表示するための文字列を登録


### PR DESCRIPTION
メールアドレスにユーザIDが初期値設定されていたけど、ユーザIDはメールアドレスではなくしたので、この初期値設定を外した。