### PR TITLE
[fix] #166対応　都道府県を選択したら他項目を初期化します。

### DIFF
--- a/src/main/java/com/portal/a/employee/controller/empController.java
+++ b/src/main/java/com/portal/a/employee/controller/empController.java
@@ -611,6 +611,9 @@ public class empController {
             }
 
         } catch (DataIntegrityViolationException e) {
+            
+            
+            
             // 参照整合性エラーが発生した時はビジネス例外として返す。
             String message = "この社員は役職がついているか経歴が残っているかユーザ情報";
             String messageKey = "e.co.fw.2.023";

--- a/src/main/resources/static/js/portal.js
+++ b/src/main/resources/static/js/portal.js
@@ -50,4 +50,16 @@ $(function() {
                 });
         }
     });
+
+    // 都道府県検索
+    $('#address1').on('change', function() {
+        //　検索後は他項目を初期化します。
+        $("#zipcode").val("");
+        $("#prefcode").val("");
+        $("#address2").val("");
+        $("#address3").val("");
+        $("#kana1").val("");
+        $("#kana2").val("");
+        $("#kana3").val("");
+    });
 });


### PR DESCRIPTION
・郵便番号検索後に都道府県名だけを修正すると、住所が矛盾してしまうため、都道府県を選択したら他の住所項目を初期化します。